### PR TITLE
[백]ResponseEntity생성

### DIFF
--- a/BackEnd/src/main/java/com/capstone/pathproject/controller/MemberApiController.java
+++ b/BackEnd/src/main/java/com/capstone/pathproject/controller/MemberApiController.java
@@ -3,6 +3,7 @@ package com.capstone.pathproject.controller;
 import com.capstone.pathproject.dto.MemberDTO;
 import com.capstone.pathproject.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,9 +15,7 @@ public class MemberApiController {
     private final MemberService memberService;
 
     @PostMapping("/signup")
-    public String signup(MemberDTO memberDTO) {
-        Long memberId = memberService.signup(memberDTO);
-        System.out.println(memberId + "번 회원가입 완료");
-        return "회원가입 완료";
+    public ResponseEntity signup(MemberDTO memberDTO) {
+        return memberService.signup(memberDTO);
     }
 }

--- a/BackEnd/src/main/java/com/capstone/pathproject/dto/response/Message.java
+++ b/BackEnd/src/main/java/com/capstone/pathproject/dto/response/Message.java
@@ -1,0 +1,20 @@
+package com.capstone.pathproject.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class Message {
+    private StatusEnum status;
+    private String message;
+    private Object data;
+
+
+    public Message(StatusEnum status, String message, Object data) {
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+}

--- a/BackEnd/src/main/java/com/capstone/pathproject/dto/response/StatusEnum.java
+++ b/BackEnd/src/main/java/com/capstone/pathproject/dto/response/StatusEnum.java
@@ -1,0 +1,24 @@
+package com.capstone.pathproject.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public enum StatusEnum {
+    OK(200, "OK"),
+    BAD_REQUEST(400, "BAD_REQUEST"),
+    NOT_FOUND(404, "NOT_FOUND"),
+    INTERNAL_SERER_ERROR(500, "INTERNAL_SERVER_ERROR");
+
+    int statusCode;
+    String code;
+
+    StatusEnum(int statusCode, String code) {
+        this.statusCode = statusCode;
+        this.code = code;
+    }
+}

--- a/BackEnd/src/main/java/com/capstone/pathproject/service/MemberService.java
+++ b/BackEnd/src/main/java/com/capstone/pathproject/service/MemberService.java
@@ -2,8 +2,13 @@ package com.capstone.pathproject.service;
 
 import com.capstone.pathproject.domain.member.Member;
 import com.capstone.pathproject.dto.MemberDTO;
+import com.capstone.pathproject.dto.response.Message;
+import com.capstone.pathproject.dto.response.StatusEnum;
 import com.capstone.pathproject.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,17 +23,39 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public Long signup(MemberDTO memberDTO) {
+    public ResponseEntity signup(MemberDTO memberDTO) {
+        HttpHeaders headers = new HttpHeaders();
+        String isEmptyMemberDTOResult = isEmptyMemberDTO(memberDTO);
+        if (!isEmptyMemberDTOResult.equals("notEmpty")) {
+            Message message = new Message(StatusEnum.BAD_REQUEST, isEmptyMemberDTOResult, memberDTO);
+            return new ResponseEntity<>(message, headers, HttpStatus.BAD_REQUEST);
+        }
         Member member = memberDTO.toEntity();
-        validateDuplicateMember(member);
-        memberRepository.save(member);
-        return member.getId();
+        if (isValidateDuplicateMember(member)) {
+            Message message = new Message(StatusEnum.BAD_REQUEST, "회원이 존재함", member);
+            return new ResponseEntity<>(message, headers, HttpStatus.BAD_REQUEST);
+        } else {
+            memberRepository.save(member);
+            Message message = new Message(StatusEnum.OK, "회원 가입 성공", member);
+            return new ResponseEntity<>(message, headers, HttpStatus.OK);
+        }
     }
 
-    private void validateDuplicateMember(Member member) {
+    private String isEmptyMemberDTO(MemberDTO memberDTO) {
+        if (memberDTO.getType() == null) return "Type 값이 비어있음";
+        if (memberDTO.getLoginId().isEmpty()) return "loginId 값이 비어있음";
+        if (memberDTO.getPassword().isEmpty()) return "password 값이 비어있음";
+        if (memberDTO.getMail().isEmpty()) return "mail 값이 비어있음";
+        if (memberDTO.getName().isEmpty()) return "name 값이 비어있음";
+        if (memberDTO.getPhone().isEmpty()) return "phone 값이 비어있음";
+        if (memberDTO.getAddr().isEmpty()) return "addr 값이 비어있음";
+        if (memberDTO.getGender() == null) return "gender 값이 비어있음";
+        if (memberDTO.getBirthday().isEmpty()) return "birthday 값이 비어있음";
+        return "notEmpty";
+    }
+
+    private boolean isValidateDuplicateMember(Member member) {
         List<Member> findMembers = memberRepository.findByLoginId(member.getLoginId());
-        if (!findMembers.isEmpty()) {
-            throw new IllegalStateException("이미 존재하는 회원입니다.");
-        }
+        return !findMembers.isEmpty();
     }
 }

--- a/BackEnd/src/test/java/com/capstone/pathproject/controller/MemberApiControllerTest.java
+++ b/BackEnd/src/test/java/com/capstone/pathproject/controller/MemberApiControllerTest.java
@@ -1,11 +1,16 @@
 package com.capstone.pathproject.controller;
 
-import com.capstone.pathproject.domain.member.Member;
+import com.capstone.pathproject.domain.member.memberGender;
+import com.capstone.pathproject.domain.member.memberType;
 import com.capstone.pathproject.dto.MemberDTO;
+import com.capstone.pathproject.dto.response.Message;
 import com.capstone.pathproject.service.MemberService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -15,19 +20,39 @@ import static org.junit.jupiter.api.Assertions.*;
 class MemberApiControllerTest {
 
     @Autowired
-    MemberService memberService;
+    private MemberService memberService;
 
     @Test
-    void signupTest() throws Exception {
+    void signup_빈객체_테스트() throws Exception {
+        //given
+        MemberDTO memberDTO = MemberDTO.createMemberDTO().build();
+        //when
+        ResponseEntity<Message> response = memberService.signup(memberDTO);
+        //then
+        System.out.println(response.getStatusCode());
+        System.out.println(response.getBody().getMessage());
+        System.out.println(response.getBody().getData().toString());
+    }
+
+    @Test
+    void signup_필수값_객체_테스트() throws Exception {
         //given
         MemberDTO memberDTO = MemberDTO.createMemberDTO()
-                .loginId("테스트아이디1")
-                .birthday("2000-02-22")
+                .type(memberType.USER)
+                .loginId("로그인아이디")
+                .password("패스워드")
+                .mail("member@naver.com")
+                .name("이름")
+                .phone("010-1234-5678")
+                .addr("대구시 동구 산격동")
+                .gender(memberGender.MALE)
+                .birthday("2000-01-01")
                 .build();
         //when
-        Long signup = memberService.signup(memberDTO);
+        ResponseEntity<Message> response = memberService.signup(memberDTO);
         //then
-        System.out.println("회원가입 완료 " + signup);
-        System.out.println("========================");
+        System.out.println(response.getStatusCode());
+        System.out.println(response.getBody().getMessage());
+        System.out.println(response.getBody().getData().toString());
     }
 }


### PR DESCRIPTION
### 1. 클라이언트 요청시 응답하는 response 틀 생성
ResponseEntity로 응답하는데 여기에 맞는 Message 클래스와 StatusEnum 을 생성하였음.
기존에 클라이언트에게 아무것도 응답하지 않거나 쓸모없는 값을 응답했다면 이제는 ResponseEntity로 성공과 실패를 보내줄 수 있음.
ResponseEntity로 응답하게 되면 클라이언트는 다음과 같이 받게된다.
```
{ 
  status : {
      statusCode : 200,
      code : OK
  },
  message : String
  data : Object
}
```
### 2. Member 회원가입 로직 변경
ResponseEntity로 응답함에 따라 회원가입 로직을 변경하였음.
MemberService에서 memberDTO를 받아서 로직이 실행됨.
먼저 `isEmptyMemberDTO(memberDTO)` 로 필수로 받아야하는 값들이 비어있는지 확인함.
값들이 있다면 DTO를 Entity로 변경하고 `isValidateDuplicateMember(member)` 로 중복된 회원인지 확인함.
이 후 위 조건에 따라 `new ResponseEntity>(message, headers, HttpStatus)` 를 반환함.