### PR TITLE
[백] 생성일시, 수정일시, 생성자, 수정자 컬럼 추가

### DIFF
--- a/BackEnd/src/main/java/com/capstone/pathproject/PathProjectApplication.java
+++ b/BackEnd/src/main/java/com/capstone/pathproject/PathProjectApplication.java
@@ -1,13 +1,30 @@
 package com.capstone.pathproject;
 
+import com.capstone.pathproject.security.auth.PrincipalDetails;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.util.Optional;
+
+@EnableJpaAuditing
 @SpringBootApplication
 public class PathProjectApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(PathProjectApplication.class, args);
+    }
+
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if(authentication == null || !authentication.isAuthenticated()) return null;
+        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+        return () -> Optional.of(principalDetails.getMember().getLoginId());
     }
 
 }

--- a/BackEnd/src/main/java/com/capstone/pathproject/domain/BaseEntity.java
+++ b/BackEnd/src/main/java/com/capstone/pathproject/domain/BaseEntity.java
@@ -1,0 +1,27 @@
+package com.capstone.pathproject.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity extends BaseTimeEntity {
+
+    @CreatedBy
+    @Column(name = "CREATED_MEM_ID", updatable = false)
+    private String createdBy;
+
+    @LastModifiedBy
+    @Column(name = "UPDATED_MEM_ID")
+    private String updatedBy;
+}

--- a/BackEnd/src/main/java/com/capstone/pathproject/domain/BaseTimeEntity.java
+++ b/BackEnd/src/main/java/com/capstone/pathproject/domain/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.capstone.pathproject.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+    @CreatedDate
+    @Column(name = "CREATED_DATETIME", updatable = false)
+    private LocalDateTime createdDateTime;
+
+    @LastModifiedDate
+    @Column(name = "UPDATED_DATETIME")
+    private LocalDateTime updatedDateTime;
+}

--- a/BackEnd/src/main/java/com/capstone/pathproject/domain/member/Member.java
+++ b/BackEnd/src/main/java/com/capstone/pathproject/domain/member/Member.java
@@ -1,22 +1,22 @@
 package com.capstone.pathproject.domain.member;
 
+import com.capstone.pathproject.domain.BaseTimeEntity;
 import com.capstone.pathproject.dto.member.MemberDTO;
 import lombok.*;
 import org.hibernate.annotations.DynamicUpdate;
-
 import javax.persistence.*;
 import java.time.LocalDate;
 
 @Entity
 @Getter
 @ToString
+@DynamicUpdate
 @SequenceGenerator(
         name = "MEMBER_SEQ_GENERATOR",
         sequenceName = "MEMBER_SEQ",
         initialValue = 1, allocationSize = 1)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@DynamicUpdate
-public class Member {
+public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "MEMBER_SEQ_GENERATOR")
@@ -61,9 +61,6 @@ public class Member {
     @Column(name = "MEM_BIRTH")
     private LocalDate birthday;
 
-    @Column(name = "MEM_SIGNUP_DATE")
-    private LocalDate signupDay;
-
     @Column(name = "MEM_ACCOUNT")
     private String account;
 
@@ -71,7 +68,7 @@ public class Member {
     private int score;
 
     @Builder(builderMethodName = "createMember")
-    public Member( Role role, String loginId, String password, String mail, String name, String phone, int postId, String addr, String addrDetail, String addrExtra, memberGender gender, LocalDate birthday, LocalDate signupDay, String account, int score) {
+    public Member( Role role, String loginId, String password, String mail, String name, String phone, int postId, String addr, String addrDetail, String addrExtra, memberGender gender, LocalDate birthday, String account, int score) {
         this.role = role;
         this.loginId = loginId;
         this.password = password;
@@ -84,7 +81,6 @@ public class Member {
         this.addrExtra = addrExtra;
         this.gender = gender;
         this.birthday = birthday;
-        this.signupDay = LocalDate.now();
         this.account = account;
         this.score = score;
     }
@@ -102,7 +98,6 @@ public class Member {
                 .addrDetail(addrDetail)
                 .gender(gender)
                 .birthday(birthday)
-                .signupDay(signupDay)
                 .account(account)
                 .score(score)
                 .build();

--- a/BackEnd/src/main/java/com/capstone/pathproject/dto/member/MemberDTO.java
+++ b/BackEnd/src/main/java/com/capstone/pathproject/dto/member/MemberDTO.java
@@ -49,12 +49,11 @@ public class MemberDTO {
     @Past
     private LocalDate birthday;
 
-    private LocalDate signupDay;
     private String account;
     private int score;
 
     @Builder(builderMethodName = "createMemberDTO")
-    public MemberDTO(Long id, Role role, String loginId, String password, String mail, String name, String phone, int postId, String addr, String addrDetail, String addrExtra, memberGender gender, LocalDate birthday, LocalDate signupDay, String account, int score) {
+    public MemberDTO(Long id, Role role, String loginId, String password, String mail, String name, String phone, int postId, String addr, String addrDetail, String addrExtra, memberGender gender, LocalDate birthday, String account, int score) {
         this.id = id;
         this.role = role;
         this.loginId = loginId;
@@ -68,7 +67,6 @@ public class MemberDTO {
         this.addrExtra = addrExtra;
         this.gender = gender;
         this.birthday = birthday;
-        this.signupDay = signupDay;
         this.account = account;
         this.score = score;
     }

--- a/BackEnd/src/test/java/com/capstone/pathproject/controller/MemberApiControllerTest.java
+++ b/BackEnd/src/test/java/com/capstone/pathproject/controller/MemberApiControllerTest.java
@@ -52,7 +52,6 @@ class MemberApiControllerTest {
                 .addrExtra("산격동")
                 .gender(memberGender.MALE)
                 .birthday(LocalDate.parse("2000-01-01"))
-                .signupDay(LocalDate.now())
                 .account("계좌")
                 .score(100)
                 .build();
@@ -72,7 +71,6 @@ class MemberApiControllerTest {
                 .addrExtra("산격동")
                 .gender(memberGender.MALE)
                 .birthday(LocalDate.parse("2000-01-01"))
-                .signupDay(LocalDate.now())
                 .account("계좌")
                 .score(100)
                 .build();


### PR DESCRIPTION
- 생성일시, 수정일시, 생성자, 수정자는 다른 테이블에서도 많이 쓰이는 컬럼들이라 쉽게 상속받아 추가할 수 있도록 만듬.
- 다른 Entity에서 BaseTimeEntity 상속받으면 생성일시와 수정일시 컬럼이 자동으로 생기고 데이터 값도 알아서 처리해줌.
- BaseEntity를 상속받으면 생성일시, 수정일시, 생성자, 수정자 컬럼이 생기고 알아서 값을 처리해줌. 이 때 생성자와 수정자는 Security의 세션에서 사용자정보를 가져오므로 로그인 후 사용하면 됨.