### PR TITLE
[백] 회원 토큰값 수정

### DIFF
--- a/BackEnd/src/main/java/com/capstone/pathproject/security/auth/jwt/JwtAuthorizationFilter.java
+++ b/BackEnd/src/main/java/com/capstone/pathproject/security/auth/jwt/JwtAuthorizationFilter.java
@@ -103,7 +103,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
             if (isValidateCookie(refreshTokenCookie)) {
                 String refreshToken = cookieUtil.exchangeToken(refreshTokenCookie).replace(JwtProperties.TOKEN_PREFIX, "");
                 if (jwtTokenUtil.isRefreshTokenExpireReissueTime(refreshToken)) {
-                    if (isTokenEqualsRedisValue(request, response, token)) {
+                    if (isTokenEqualsRedisValue(request, response, refreshToken)) {
                         reissueRefreshToken(request, response, principalDetails);
                     }
                 }

--- a/BackEnd/src/main/java/com/capstone/pathproject/security/auth/jwt/JwtProperties.java
+++ b/BackEnd/src/main/java/com/capstone/pathproject/security/auth/jwt/JwtProperties.java
@@ -2,11 +2,12 @@ package com.capstone.pathproject.security.auth.jwt;
 
 public interface JwtProperties {
     String SECRET = "path_secret";
-    int EXPIRATION_TIME = 60 * 1000 * 10;
+    int EXPIRATION_TIME = 10 * 60 * 1000; // 15분
     String HEADER_STRING = "Authorization";
     String TOKEN_PREFIX = "Bearer ";
 
     String REFRESH = "path_refresh";
     String REFRESH_HEADER_STRING = "RefreshToken";
-    int REFRESH_EXPIRATION_TIME = 24 * 60 * 60 * 1000;
+    int REFRESH_EXPIRATION_TIME = 60 * 60 * 1000; // 1시간
+//    int REFRESH_EXPIRATION_TIME = 24 * 60 * 60 * 1000;
 }

--- a/BackEnd/src/main/java/com/capstone/pathproject/util/ClientUtil.java
+++ b/BackEnd/src/main/java/com/capstone/pathproject/util/ClientUtil.java
@@ -28,7 +28,6 @@ public class ClientUtil {
             ip = request.getHeader("HTTP_X_FORWARDED_FOR");
             log.info(">>>> HTTP_X_FORWARDED_FOR : " + ip);
         }
-
         if (ip == null) {
             ip = request.getRemoteAddr();
         }

--- a/BackEnd/src/main/java/com/capstone/pathproject/util/JwtTokenUtil.java
+++ b/BackEnd/src/main/java/com/capstone/pathproject/util/JwtTokenUtil.java
@@ -101,7 +101,7 @@ public class JwtTokenUtil {
         long expiration = claimsFormToken.getExpiration().getTime();
         long now = new Date().getTime();
         if (expiration >= now && expiration - 600000 <= now) {
-            log.info("RefreshToken 갱신 필요 : {}", expiration);
+            log.info("RefreshToken 갱신 필요 : {}", new Date(expiration));
             return true;
         }
         log.info("RefreshToken 갱신 불필요 : {}", expiration);


### PR DESCRIPTION
- Refresh Token으로 재인증할 때 잘못된 토큰값으로 검증하고 있는 부분 수정
- AccessToken 15분 유효
- RefreshToken 1시간 유효

서버에 매 요청시마다 재발급 로직 실행됨.
액세스 토큰은 1회용으로 쓰임. 새로고침을 하면 사라짐.
리프레시 토큰은 만료시간이 10분 이내면 재발급함.