### PR TITLE
[백] 원클릭오더 에러 체크

### DIFF
--- a/BackEnd/src/main/java/com/capstone/pathproject/repository/company/CompanyRepository.java
+++ b/BackEnd/src/main/java/com/capstone/pathproject/repository/company/CompanyRepository.java
@@ -3,10 +3,10 @@ package com.capstone.pathproject.repository.company;
 import com.capstone.pathproject.domain.company.CompCategory;
 import com.capstone.pathproject.domain.company.Company;
 import com.capstone.pathproject.domain.member.Member;
-import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;

--- a/BackEnd/src/main/java/com/capstone/pathproject/repository/product/ProductRepository.java
+++ b/BackEnd/src/main/java/com/capstone/pathproject/repository/product/ProductRepository.java
@@ -3,9 +3,10 @@ package com.capstone.pathproject.repository.product;
 import com.capstone.pathproject.domain.company.CompCategory;
 import com.capstone.pathproject.domain.company.Company;
 import com.capstone.pathproject.domain.company.Product;
-import io.lettuce.core.dynamic.annotation.Param;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 


### PR DESCRIPTION
java8버전 이상부터 -parameters라는 컴파일러 플래그를 지원하고 있는데 이러면 매개변수 이름으로 바인딩을 지원합니다. 하지만 자바 컴파일러가 설정안된 경우도 있으므로 제대로 `@Param`을 쓰는것이 좋습니다. 현재 레포지토리에서는 import가 잘못되어 있어서 수정하였습니다.